### PR TITLE
Fix compile error on Linux

### DIFF
--- a/sys/config/src/config_cli.c
+++ b/sys/config/src/config_cli.c
@@ -57,7 +57,7 @@ shell_conf_command(int argc, char **argv)
         } else {
             val = "Done\n";
         }
-        console_printf(val);
+        console_printf("%s", val);
         return 0;
     }
     if (!val) {


### PR DESCRIPTION
error: format not a string literal and no format arguments
   [-Werror=format-security]