### PR TITLE
Make constants consistent between newt and larva repos

### DIFF
--- a/libs/newtmgr/include/newtmgr/newtmgr.h
+++ b/libs/newtmgr/include/newtmgr/newtmgr.h
@@ -55,8 +55,8 @@
  */
 #define NMGR_ID_ECHO	        0
 #define NMGR_ID_CONS_ECHO_CTRL  1
-#define NMGR_ID_TASKSTAT        2
-#define NMGR_ID_MPSTAT          3
+#define NMGR_ID_TASKSTATS       2
+#define NMGR_ID_MPSTATS         3
 
 struct nmgr_hdr {
     uint8_t nh_op;

--- a/libs/newtmgr/src/newtmgr.c
+++ b/libs/newtmgr/src/newtmgr.c
@@ -54,8 +54,8 @@ static struct nmgr_group nmgr_def_group;
 static const struct nmgr_handler nmgr_def_group_handlers[] = {
     [NMGR_ID_ECHO] = {nmgr_def_echo, nmgr_def_echo},
     [NMGR_ID_CONS_ECHO_CTRL] = {nmgr_def_console_echo, nmgr_def_console_echo},
-    [NMGR_ID_TASKSTAT] = {nmgr_def_taskstat_read, NULL},
-    [NMGR_ID_MPSTAT] = {nmgr_def_mpstat_read, NULL},
+    [NMGR_ID_TASKSTATS] = {nmgr_def_taskstat_read, NULL},
+    [NMGR_ID_MPSTATS] = {nmgr_def_mpstat_read, NULL},
 };
 
 /* JSON buffer for NMGR task


### PR DESCRIPTION
NMGR_ID_TASKSTAT => NMGR_ID_TASKSTATS
NMGR_ID_MPSTAT => NMGR_ID_MPSTATS