### PR TITLE
Support building 'sim' with optimization levels higher than -O0

### DIFF
--- a/compiler/sim/pkg.yml
+++ b/compiler/sim/pkg.yml
@@ -29,15 +29,16 @@ pkg.keywords:
     - gcc
 
 compiler.path.cc: "/usr/local/bin/gcc-5" 
+compiler.path.as: "/usr/local/bin/gcc-5 -x assembler-with-cpp"
 compiler.path.archive: "ar"
 compiler.path.objdump: "gobjdump"
 compiler.path.objsize: "objsize"
 compiler.path.objcopy: "gobjcopy"
 
 compiler.flags.base: >
-    -m32 -Wall -Werror -ggdb -O0 -DMN_OSX
+    -m32 -Wall -Werror -ggdb -DMN_OSX
 
-compiler.flags.default: [compiler.flags.base]
-compiler.flags.debug: [compiler.flags.base, -ggdb -O0]
+compiler.flags.default: [compiler.flags.base, -O1]
+compiler.flags.debug: [compiler.flags.base, -O0]
 
 compiler.ld.mapfile: false

--- a/libs/os/src/arch/sim/os_arch_stack_frame.s
+++ b/libs/os/src/arch/sim/os_arch_stack_frame.s
@@ -1,0 +1,68 @@
+    .text
+    .code32
+    .p2align 4, 0x90    /* align on 16-byte boundary and fill with NOPs */
+
+    .globl _os_arch_frame_init
+    /*
+     * void os_arch_frame_init(struct stack_frame *sf)
+     */
+_os_arch_frame_init:
+    push    %ebp                    /* function prologue for backtrace */
+    mov     %esp,%ebp
+    push    %esi                    /* save %esi before using it as a tmpreg */
+
+    /*
+     * At this point we are executing on the main() stack:
+     * ----------------
+     * stack_frame ptr      0xc(%esp)
+     * ----------------
+     * return address       0x8(%esp)
+     * ----------------
+     * saved ebp            0x4(%esp)
+     * ----------------
+     * saved esi            0x0(%esp)
+     * ----------------
+     */
+    movl    0xc(%esp),%esi          /* %esi = 'sf' */
+    movl    %esp,0x0(%esi)          /* sf->mainsp = %esp */
+
+    /*
+     * Switch the stack so the stack pointer stored in 'sf->sf_jb' points
+     * to the task stack. This is slightly complicated because OS X wants
+     * the incoming stack pointer to be 16-byte aligned.
+     *
+     * ----------------
+     * sf (other fields)
+     * ----------------
+     * sf (sf_jb)           0x4(%esi)
+     * ----------------
+     * sf (sf_mainsp)       0x0(%esi)
+     * ----------------
+     * alignment padding    variable (0 to 12 bytes)
+     * ----------------
+     * pointer to sf_jb     %esp
+     * ----------------
+     */
+    movl    %esi,%esp
+    subl    $0x4,%esp               /* make room for setjmp() argument */
+    andl    $0xfffffff0,%esp        /* align %esp on 16-byte boundary */
+    leal    0x4(%esi),%eax          /* %eax = &sf->sf_jb */
+    movl    %eax,0x0(%esp)
+    call    __setjmp                /* _setjmp(sf->sf_jb) */
+    test    %eax,%eax
+    jne     1f
+    movl    0x0(%esi),%esp          /* switch back to the main() stack */
+    pop     %esi
+    pop     %ebp
+    ret                             /* return to os_arch_task_stack_init() */
+1:
+    lea     2f,%ecx
+    push    %ecx                    /* retaddr */
+    push    $0                      /* frame pointer */
+    movl    %esp,%ebp               /* handcrafted prologue for backtrace */
+    push    %eax                    /* rc */
+    push    %esi                    /* sf */
+    call    _os_arch_task_start     /* os_arch_task_start(sf, rc) */
+    /* never returns */
+2:
+    nop

--- a/libs/os/src/os_sched.c
+++ b/libs/os/src/os_sched.c
@@ -138,16 +138,15 @@ os_sched(struct os_task *next_t, int isr)
     }
 
     if (next_t != g_current_task) {
-        OS_EXIT_CRITICAL(sr);
         if (isr) {
             os_arch_ctx_sw_isr(next_t);
         } else {
             os_arch_ctx_sw(next_t);
         }
 
-    } else {
-        OS_EXIT_CRITICAL(sr);
     }
+
+    OS_EXIT_CRITICAL(sr);
 }
 
 /**

--- a/libs/util/include/util/util.h
+++ b/libs/util/include/util/util.h
@@ -19,4 +19,6 @@
 #ifndef __UTIL_H__ 
 #define __UTIL_H__
 
+#define CTASSERT(x) typedef int __ctasssert ## __LINE__[(x) ? 1 : -1]
+
 #endif /* __UTIL_H__ */


### PR DESCRIPTION
0796ef213444be48b59d31e378adca2efc61a3dc:
Support building the 'sim' with optimization levels higher than -O0. The
higher optimization levels emit useful warnings that are masked at -O0.

The basic problem with the implementation of 'os_arch_task_stack_init()'
is that we are switching stacks from underneath the compiler without any
ability to influence how the compiler uses the stack. Thus when setjmp()
returns the compiler doesn't know that the stack frame it allocated for
local variables doesn't exist anymore on the new stack.

This happens to work with the -O0 optimization level because the compiler
addresses local variables using the frame pointer (%ebp). Higher optimization
levels use offsets from the stack pointer and immediately expose the issue
mentioned above.

Fix this by switching stacks in 'os_arch_frame_init()' which is implemented
in assembly so we can control the use of stack after setjmp() returns.

fb3520e2ca4aadc0d47928a0a54ebcd54a433f6e:
Don't drop the critical section between selecting the task to run and
actually switching to it. This creates a window where an interrupt might
make a higher priority task runnable but won't switch to it immediately.