### PR TITLE
Use sigsetjmp/siglongjmp since they are portable across OS X and Linux.

### DIFF
--- a/libs/os/src/arch/sim/os_arch_sim.c
+++ b/libs/os/src/arch/sim/os_arch_sim.c
@@ -35,7 +35,7 @@
 
 struct stack_frame {
     int sf_mainsp;              /* stack on which main() is executing */
-    jmp_buf sf_jb;
+    sigjmp_buf sf_jb;
     int sf_sigsblocked;
     struct os_task *sf_task;
 };
@@ -55,8 +55,8 @@ extern void os_arch_frame_init(struct stack_frame *sf);
 #define ISR_BLOCK_OFF (0) 
 #define ISR_BLOCK_ON (1)
 
-#define sim_setjmp(__jb) _setjmp(__jb)
-#define sim_longjmp(__jb, __ret) _longjmp(__jb, __ret) 
+#define sim_setjmp(__jb) sigsetjmp(__jb, 0)
+#define sim_longjmp(__jb, __ret) siglongjmp(__jb, __ret) 
 
 sigset_t g_sigset;  
 volatile int g_block_isr = ISR_BLOCK_OFF;

--- a/libs/os/src/arch/sim/os_arch_stack_frame.s
+++ b/libs/os/src/arch/sim/os_arch_stack_frame.s
@@ -40,15 +40,18 @@ _os_arch_frame_init:
      * ----------------
      * alignment padding    variable (0 to 12 bytes)
      * ----------------
-     * pointer to sf_jb     %esp
+     * savemask (0)         0x4(%esp)
+     * ----------------
+     * pointer to sf_jb     0x0(%esp)
      * ----------------
      */
     movl    %esi,%esp
-    subl    $0x4,%esp               /* make room for setjmp() argument */
+    subl    $0x8,%esp               /* make room for sigsetjmp() arguments */
     andl    $0xfffffff0,%esp        /* align %esp on 16-byte boundary */
     leal    0x4(%esi),%eax          /* %eax = &sf->sf_jb */
     movl    %eax,0x0(%esp)
-    call    __setjmp                /* _setjmp(sf->sf_jb) */
+    movl    $0, 0x4(%esp)
+    call    _sigsetjmp              /* _setjmp(sf->sf_jb, 0) */
     test    %eax,%eax
     jne     1f
     movl    0x0(%esi),%esp          /* switch back to the main() stack */

--- a/libs/os/src/arch/sim/os_arch_stack_frame.s
+++ b/libs/os/src/arch/sim/os_arch_stack_frame.s
@@ -51,7 +51,7 @@ _os_arch_frame_init:
     leal    0x4(%esi),%eax          /* %eax = &sf->sf_jb */
     movl    %eax,0x0(%esp)
     movl    $0, 0x4(%esp)
-    call    _sigsetjmp              /* _setjmp(sf->sf_jb, 0) */
+    call    _sigsetjmp              /* sigsetjmp(sf->sf_jb, 0) */
     test    %eax,%eax
     jne     1f
     movl    0x0(%esi),%esp          /* switch back to the main() stack */


### PR DESCRIPTION
The behavior of 'setjmp()' is not portable across different UNIX systems.

BSD derived systems including OS X will save the signal mask whereas Linux and Solaris do not (POSIX doesn't specify behavior of setjmp/longjmp with respect to signal masks).

'sigsetjmp()' on the other hand takes an additional argument 'save mask' that indicates whether the caller wants to save the signal mask or not. In addition this function has the same behavior across all UNIX systems so use this instead of '_setjmp()'.